### PR TITLE
Make virtual executor account for `thread-factory`

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ via tools.deps
 
 ### Executors
 
-Executor can be `:fixed` `:cached` `:single` `:scheduled`, matching the
+Executor can be `:fixed` `:cached` `:single` `:scheduled` `:virtual`, matching the
 corresponding Java instances.
 
 ```Clojure

--- a/src/qbits/knit.clj
+++ b/src/qbits/knit.clj
@@ -40,11 +40,13 @@
 
 (defn executor
   "Returns an instances of an ExecutorService of the corresponding type.
-  `type` can be :single, :cached, :fixed, :scheduled, or :virtual"
+  `type` can be :single, :cached, :fixed, :scheduled, or :virtual
+  `opts` map may include `:thread-factory` (otherwise a default one will be used)
+         and `:num-threads` for :fixed and :scheduled executor (the default is 1)"
   ^ExecutorService
   ([type] (executor type nil))
   ([type {:keys [thread-factory num-threads]
-          :or {num-threads (int 1)}}]
+          :or {num-threads (int 1)} :as _opts}]
    (if (= :virtual type)
      (if (some? thread-factory)
        (do (assert (= ThreadBuilders$VirtualThreadFactory (type thread-factory)))

--- a/src/qbits/knit.clj
+++ b/src/qbits/knit.clj
@@ -57,7 +57,7 @@
          :single (Executors/newSingleThreadExecutor thread-factory)
          :cached (Executors/newCachedThreadPool thread-factory)
          :fixed (Executors/newFixedThreadPool (int num-threads) thread-factory)
-         :scheduled (Executors/newScheduledThreadPool (int num-threads) thread-factory)))))
+         :scheduled (Executors/newScheduledThreadPool (int num-threads) thread-factory))))))
 
 (defn schedule
   "Return a ScheduledFuture.

--- a/src/qbits/knit.clj
+++ b/src/qbits/knit.clj
@@ -49,7 +49,7 @@
           :or {num-threads (int 1)} :as _opts}]
    (if (= :virtual type)
      (if (some? thread-factory)
-       (do (assert (= ThreadBuilders$VirtualThreadFactory (type thread-factory)))
+       (do (assert (= ThreadBuilders$VirtualThreadFactory (class thread-factory)))
            (Executors/newThreadPerTaskExecutor thread-factory))
        (Executors/newVirtualThreadPerTaskExecutor))
      (let [thread-factory (or thread-factory (Executors/defaultThreadFactory))]

--- a/src/qbits/knit.clj
+++ b/src/qbits/knit.clj
@@ -47,7 +47,7 @@
           :or {num-threads (int 1)}}]
    (if (= :virtual type)
      (if (some? thread-factory)
-       (do (assert (instance? ThreadBuilders$VirtualThreadFactory thread-factory))
+       (do (assert (= ThreadBuilders$VirtualThreadFactory (type thread-factory)))
            (Executors/newThreadPerTaskExecutor thread-factory))
        (Executors/newVirtualThreadPerTaskExecutor))
      (let [thread-factory (or thread-factory (Executors/defaultThreadFactory))]


### PR DESCRIPTION
Hi @mpenet and thank you for this slick lib!

I recently came across an inconvenience that forced me to step back from using the `executor` fn for `ExecutorService` creation. I needed to pass a custom `thread-factory` which it didn't expect.

So, here it is. An augmented version of the `executor` fn that allows for exactly this.

Please, feel free to incorporate this small feature or ask me for further improvements anytime.