### PR TITLE
Make virtual executor account for `thread-factory`

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ via tools.deps
 
 ### Executors
 
-Executor can be `:fixed` `:cached` `:single` `:scheduled`, matching the
-corresponding Java instances.
+Executor can be `:fixed` `:cached` `:single` `:scheduled` `:scheduled-single` `:thread-per-task` `:virtual`,
+matching the corresponding Java instances.
 
 ```Clojure
 (def x (executor :fixed))


### PR DESCRIPTION
Hi @mpenet and pardon for reopening #3!

Your recent changes are a step in the right direction, but I must admit that they do not solve the original issue.
I still needed to be able to pass a custom `thread-factory`, which the `executor` fn doesn't expect.

I re-applied the required changes on top of the version `2.0.2`.

Please, feel free to incorporate this small feature or ask me for further improvements anytime.